### PR TITLE
Link link hover effect updates

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -21,10 +21,6 @@ a .news.item figure, a .news.item h3 {
   cursor: pointer;
 }
 
-a {
-  text-decoration: none;
-}
-
 a:hover h3 {
   text-decoration: underline;
 }

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1423,7 +1423,7 @@ img {
 /* Base Typography */
 
 a {
-    text-decoration: underline 2px var(--light-gray-80);
+    text-decoration: underline 2px var(--gold-solid);
     text-underline-position: under;    
 }
 
@@ -1495,10 +1495,12 @@ strong {
 }
 
 .body-container p a {
-    background-image: linear-gradient(var(--light-gray-80) 0 0);
+    background-image: linear-gradient(var(--gold-solid) 0 0);
     background-size: 200% 0px;
     background-position: 200% 100%;
     background-repeat: no-repeat;
+    padding: 3px;
+    margin: -3px;
     transition: background-size .3s, background-position .3s .3s;
 }
 


### PR DESCRIPTION
- Addresses incorrect global scoping of <a> elements that was supressing underlines in body copy.
- Changes link underline and hover effect colors from wireframe gray to brand gold.