### PR TITLE
In-content image enlargement and caption changes

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1766,7 +1766,7 @@ a.content-button.secondary:hover {
     font-weight: 300;
     font-size: .925rem;
     color: #3c3c3c;
-    margin-top: 0;
+    margin-top: 10px;
     line-height: 1.25rem;
 }
 
@@ -1889,8 +1889,7 @@ a.content-button.secondary:hover {
 /* In-content Image */
 
 .in-content-image {
-    max-width: 300px;
-    background-color: var(--wireframe-placeholder);
+    max-width: 50%;
 }
 .in-content-image img {
     vertical-align: top;
@@ -1900,12 +1899,12 @@ a.content-button.secondary:hover {
 }
 
 .in-content-image.left {
-    float:left;
+    float: left;
     margin: 20px 30px 20px -100px;
 }
 
 .in-content-image.right {
-    float:right;
+    float: right;
     margin: 20px -100px 20px 20px;
 }
 
@@ -1960,12 +1959,10 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
 
     .in-content-image.left {
         margin: 20px 30px 20px 0;
-        max-width: 50%;
     }
 
     .in-content-image.right {
         margin: 20px 0 20px 20px;
-        max-width: 50%;   
     }
 }
 


### PR DESCRIPTION
Makes minor changes to in-content images and captions:

- Enlarges default size for in-content left/right images on desktop.
- Removes media queries for mobile that are no longer needed due to overall increase in image size
- Removes placeholder image background color
- Adds 10px of space above captions


Works to address #27.