### PR TITLE
Changes to Text-Only Hero styling

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -371,8 +371,6 @@ main#content.no-margin {
     margin: 0;
 }
 
-
-
 /* ===================
 	Header Navigation
    =================== */
@@ -2246,7 +2244,7 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
 /* Variant - No Image */
 
 .hero.simple {
-    background-color: var(--light-gray-80);
+    background-color: unset;
     min-height: unset;
 }
 

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1822,8 +1822,13 @@ a.content-button.secondary:hover {
     display: grid;
     grid-template-columns: 2fr 1fr;
     grid-gap: 60px;
+    width: calc(100% - 30px);
     max-width: 1200px;
     margin: auto;
+}
+
+.body-container.two-col .body-section {
+    max-width: unset;
 }
 
  .body-container.two-col .full-width {
@@ -2249,9 +2254,11 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
 }
 
 .hero.simple .hero-content {
-    margin-left: calc(50% - 450px);
-    padding: 50px 0;
-    max-width: 900px;
+    max-width: 1230px;
+    width: 100%;
+    padding-left: 15px;	
+    padding-right: 15px;
+    margin: auto;
 }
 
 .hero.simple .hero-content h1 span {


### PR DESCRIPTION
Addresses #25 via the following:

- Allows text-only heading to align with the left margin of body content in a 2-column layout.
- Removes gray placeholder background from hero area
- Adjusts two-column content area width and margins (regardless of hero selection) to make better use of space and ensure gutters exist at all breakpoints

