### PR TITLE
Newsroom header label contrast

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -3444,6 +3444,10 @@ p.tag-primary + h3 {
 	display: none;
 }
 
+.newsroom-vertical .vertical-name {
+	background: rgba(255, 255, 255, .85); /* using rgba instead of hex for better transparency performance */
+}
+
 .magazine-vertical .issue-date {
 	display: block;
 }


### PR DESCRIPTION
Adds a background color with transparency to the newsroom header variant to resolve contrast issues when overlapping the article hero