### PR TITLE
Full-width region grid update

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -157,6 +157,10 @@ blockquote.pull-quote.quote-marks:after {
     max-width: inherit;
 }
 
+.full-bleed-section .content-constrain figure {
+    height: unset
+}
+
 /* -- NOTE: THIS SECTION OF STYLES OVERRIDES THOSE ABOVE BASED ON A NEW PROPOSED DESIGN.
 WHEN THE STYLE BELOW ARE APPROVED, THIS SECTION MUST BE REFACTOR WITH THAT ABOVE*/
 


### PR DESCRIPTION
- Fixes a bug that prevented .`grid-snippet` from expanding to body margins when places in the full-width region.
- Fixes a bug that causes images to be too tall when places in the full width region