### PR TITLE
Hub layout tweaks for lead story

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -2881,6 +2881,16 @@ UPDATE THIS CLASS FOR THE PAGE
     object-fit: cover;
 }
 
+/* Lead Story Hub Styles -- Includes Layout Tweaks Specific to Headline Area  */
+
+.headline-area .grid-snippet.lead {
+  margin-top: -40px;
+}
+
+.grid-snippet.lead {
+  display: block;
+}
+
 .item.text-block {
     background: none;
 }
@@ -2906,17 +2916,6 @@ UPDATE THIS CLASS FOR THE PAGE
 
 .item.news p {
     font-size: 1.25rem;
-}
-
-.lead .item.news h1 {
-    font-family: proxima-nova, sans-serif;
-	font-weight: 700;
-	margin-bottom: 0;
-	padding: 0;
-	text-align: left;
-	margin: 20px 0;
-	font-size: 2rem;
-	line-height: 2.25rem;
 }
 
 .grid-snippet h2, .item.news h3 {
@@ -2968,9 +2967,37 @@ UPDATE THIS CLASS FOR THE PAGE
 
 /* MQs */
 
+@media only screen and (max-width: 960px) {
+    .grid-snippet.four {
+        grid-template-columns: 1fr 1fr;
+    }
+
 @media only screen and (max-width: 720px) {
     .grid-snippet, .grid-snippet.one, .grid-snippet.two, .grid-snippet.three, .grid-snippet.four {
         grid-template-columns: 1fr;
+    }
+
+  .lead .news.item .copy :first-child {
+    margin-top: 0;
+    }
+
+  .lead .news.item .copy :last-child {
+    margin-bottom: 0;
+    }
+
+  .lead .news.item .copy {
+    width: 100%;
+    margin: auto;
+    }
+
+  .lead figure img {
+    aspect-ratio: 1.25;
+    }
+
+  .headline-area .grid-snippet.lead figure {
+    width: 100vw;
+    margin-left: -20px;
+    position: relative;
     }
 }
 


### PR DESCRIPTION
- Adds styling specific to the placement of the lead news item in the headline region of the hub. Allows the lead story to extend to the margins of the page in this region.
- Various type, margin and size changes for the hub lead news item on mobile.
- Adjust MQs for grid control. Allows 4-up articles to display in two columns between 720 and 960 px.