### PR TITLE
Fix display of split feature grid

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -2999,6 +2999,10 @@ UPDATE THIS CLASS FOR THE PAGE
     grid-template-columns: 1fr 1fr;
 }
 
+.split .item.news a {
+    display: contents;
+}
+
 .split .item.news .copy {
     padding: 20px;
     display: flex;


### PR DESCRIPTION
Fixes broken display of the "split" feature variant that occurred when the entire object was wrapped in a link