### PR TITLE
Add .no-animate class

### DIFF
--- a/css/animate-custom.css
+++ b/css/animate-custom.css
@@ -4112,3 +4112,9 @@
   -webkit-animation-delay: calc(var(--animate-delay) * 1.5);
   animation-delay: calc(var(--animate-delay) * 1.5);
 }
+
+/* === UTILITY CLASSES TO KILL ANIMATIONS WHEN DESIRED === */
+
+.no-animate.hero :where(div, h1, p) {
+  animation: none;
+}	


### PR DESCRIPTION
Adds a utility class of .no-animate to kill animation. In this case, scoped to the text-only hero. May add additional classes in the future.