### PR TITLE
refactor-hub-styles

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -2754,10 +2754,6 @@ UPDATE THIS CLASS FOR THE PAGE
     margin: 40px auto;;
 }
 
-.grid-snippet .item {
-    background-color: #eee;
-}
-
 .grid-snippet.one {
     grid-template-columns: 1fr;
 }
@@ -3015,55 +3011,8 @@ UPDATE THIS CLASS FOR THE PAGE
     aspect-ratio: 1;
 }
 
-/* MQs */
-
-@media only screen and (max-width: 960px) {
-    .grid-snippet.four {
-        grid-template-columns: 1fr 1fr;
-    }
-}
-
-@media only screen and (max-width: 720px) {
-    .grid-snippet, .grid-snippet.one, .grid-snippet.two, .grid-snippet.three, .grid-snippet.four {
-        grid-template-columns: 1fr;
-    }
-
-  .lead .news.item .copy :first-child {
-    margin-top: 0;
-    }
-
-  .lead .news.item .copy :last-child {
-    margin-bottom: 0;
-    }
-
-  .lead .news.item .copy {
-    width: 100%;
-    margin: auto;
-    }
-
-  .lead figure img {
-    aspect-ratio: 1.25;
-    }
-
-  .headline-area .grid-snippet.lead figure {
-    width: 100vw;
-    position: relative;
-    }
-}
-
-
-/* =================================================
-
-   More Landing Page CSS
-
-   ================================================= */
-
 .grid-snippet {
     min-height: unset;
-}
-
-.grid-snippet .item {
-    background: none;
 }
 
 .grid-snippet.lead {
@@ -3127,32 +3076,47 @@ p.tag-primary + h3 {
 	border-bottom: 1px solid #ccc;
 }
 
+/* MQs */
 
-/* Container Queriess -- still testing these
-
-.item.news {
-    container-type: inline-size;
-    container-name: test-container;
-}
-
-@container test-container (max-width: 600px) {
-    .copy h3 {
-        font-size: 1.5rem !important;
+@media only screen and (max-width: 960px) {
+    .grid-snippet.four {
+        grid-template-columns: 1fr 1fr;
     }
-
-}
-
-@container test-container (max-width: 300px) {
-    .copy h3 {
-        font-size: 1.25rem !important;
-
-    }
-    .copy p {
-        font-size: 1rem !important;
+    .split .item.news {       
+        grid-template-columns: 1.25fr 1fr;
     }
 }
-*/
 
+@media only screen and (max-width: 720px) {
+    .grid-snippet, .grid-snippet.one, .grid-snippet.two, .grid-snippet.three, .grid-snippet.four {
+        grid-template-columns: 1fr;
+    }
+
+  .lead .news.item .copy :last-child {
+    margin-bottom: 0;
+    }
+
+  .lead .news.item .copy {
+    width: 100%;
+    margin: auto;
+    }
+
+  .lead figure img {
+    aspect-ratio: 1.25;
+    }
+
+   .split .item.news {       
+     grid-template-columns: 1fr;
+     left: 0;
+     width: 100%;
+     z-index: 10; 
+     }	
+
+  .headline-area .grid-snippet.lead figure {
+    width: 100vw;
+    position: relative;
+    }
+}
 
 /* Still a work in progress. Would like to get the grid areas working with pseudoclasses.*/
 


### PR DESCRIPTION
Initial refactor and consolidation of grid snippet and related hub classes:
- Removes gray background color from grid items, and removes the override that was in place to reset that background color to none
- Moves all classes from the "additional styles" section into the main hub section -- this is required to overcome cascade issues for media queries
- Removed initial container query test classes that have remained in source but commented out since early wireframes

More detailed changes to come shorly.