### PR TITLE
Patch responsive changes

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -2826,43 +2826,13 @@ UPDATE THIS CLASS FOR THE PAGE
 /* Side-by-Side Grid Layout Variant */
 
 .grid-snippet.horizontal .news.item a {
-    grid-template-columns: 2fr 3fr; /* Two columns: one for the first child and one for the rest */
+    grid-template-columns: 2fr 3fr;
     display: grid;
-    grid-column-gap: 20px;
-    grid-template-rows: repeat(4, min-content);
+    grid-gap: 20px;
 }
 
-/* Target the first child of each object, which will always be the figure */
-.grid-snippet.horizontal .news.item figure {
-    grid-column: 1; /* Place the figure in the first column */
-    grid-row: 1 / 4;
-    width: auto;
-    height: fit-content;	
-}
-
-/* Target all other children and force them into the second column */
-    .grid-snippet.horizontal .news.item :not(figure) {
-    grid-column: 2;
-    margin-top: 0;	    
-}
-
-/* This is all a but clunky but it works -- need to refine later as time allows */
-
-.grid-snippet.horizontal .news.item p.tag-primary {
-    margin-bottom: 0;
-}
-
-.grid-snippet.horizontal .news.item a {
-    grid-template-rows: repeat(4, fit-content(1%));
-    min-height: fit-content;
-  }
-
-.grid-snippet.horizontal .news.item * {
-    margin-bottom: 10px;
-}
-
-.grid-snippet.horizontal .news-item {
-    height: fit-content;
+.grid-snippet.horizontal .news.item div:first-of-type {
+    margin-top: 0;
 }
 
 /* These styles supress various elements of the parent object */

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -3048,7 +3048,21 @@ p.tag-primary + h3 {
     }
 }
 
-@media only screen and (max-width: 720px) {
+/* Displays 3-up items horizontally to avoid orphans when the number of items is odd */
+
+@media only screen and (max-width: 720px) and (min-width: 501px) {
+.grid-snippet.three .news.item a {
+    grid-template-columns: 2fr 3fr;
+    display: grid;
+    grid-gap: 20px;
+    }
+
+.grid-snippet.three .news.item div:first-of-type {
+    margin-top: 0;
+    }
+}
+
+@media only screen and (max-width: 500px) {
     .grid-snippet, .grid-snippet.one, .grid-snippet.two, .grid-snippet.three, .grid-snippet.four {
         grid-template-columns: 1fr;
     }


### PR DESCRIPTION
Addresses responsive grids on hub pages, specifically:
 - Introduced a horizontal item layout for the 3-column display on midsize screens, to avoid awkward item breaks and orphans
 - Changes breakpoint for 2-up items to 500px to avoid oversized items between 500 and 720px