### PR TITLE
Typography and minor style updates

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -197,7 +197,8 @@ blockquote.pull-quote.quote-marks p:not(.attrib):after {
 
 /* Normalizes the top alignment of main body and sidebar when one or both sections lead with an element with a margin-top value other than 0 */
 
-.body-container.two-col .main-content :first-child, .body-container.two-col .secondary-content :first-child:not(.full-bleed-section *) {
+.body-container.two-col .main-content .body-section > *:first-of-type,
+.body-container.two-col .secondary-content :first-child:not(.full-bleed-section *) {
 	margin-top:0;
 }
 

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1575,7 +1575,8 @@ blockquote.pull-quote.quote p.attrib {
 .card, .cards > * {					/* use .card for single element; use .cards to style all children */
     padding: 20px;
     background: var(--lightest-gray);
-    box-shadow: 5px 5px 7px var(--light-gray);
+ /* box-shadow: 5px 5px 7px var(--light-gray); */
+    border: 1px solid #ccc;	
 }
 
 .cards .news.item figure {				/* neccessary to make the image extend to the borders of the card and allow text padding to remain unchanged */
@@ -2983,10 +2984,6 @@ UPDATE THIS CLASS FOR THE PAGE
 
 p.tag-primary + h3 {
 	margin-bottom: 0;
-}
-
-.card, .cards  > * {
-	background-color: #f5f5f5 !important; /* ugh */ /* lol */
 }
 
 .card .copy, .cards .copy {

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1825,7 +1825,7 @@ a.content-button.secondary:hover {
 .body-container.two-col {
     display: grid;
     grid-template-columns: 2fr 1fr;
-    grid-gap: 60px;
+    grid-gap: 6.5%;
     width: calc(100% - 30px);
     max-width: 1200px;
     margin: 40px auto;
@@ -2227,7 +2227,6 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
 
 .hero-content p.byline-item .icon {
     margin-right: 10px;
-    font-size: 1.25em;
     color: #000;
 }
 


### PR DESCRIPTION
- Addresses a bug when normalizing top margin of main content and sidebar elements (this one may continue to be trial and error)
- Changes grid gap from px to % on 2-column article layouts for better responsive scaling
- Allows byline icons to inherit font size from the byline text
- Adds additional card styling