### PR TITLE
Card style updates

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -226,6 +226,13 @@ blockquote.pull-quote.quote-marks p:not(.attrib):after {
     transition: all .1s ease-in;
 }
 
+.cards .news.item a {
+    display: inline-block;
+    height: 100%;
+    width: 100%;
+    cursor: pointer;
+}
+
 /* ==== CALLOUTS ==== */
 
 .callout.left {

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1569,7 +1569,7 @@ blockquote.pull-quote.quote p.attrib {
     position: relative;
 }
 
-/* ===== HEADER =================================== */
+/* ===== STYLE VARIANTS =================================== */
 
 
 .card, .cards > * {					/* use .card for single element; use .cards to style all children */
@@ -1587,6 +1587,11 @@ blockquote.pull-quote.quote p.attrib {
 
 .cards.grid > * {					 /* kills additional padding for grid layout */
     padding: 0px;
+}
+
+.cards .news.item figure img {
+    height: 100%;
+    object-fit: cover;
 }
 
 .shadow {
@@ -2988,7 +2993,7 @@ p.tag-primary + h3 {
 }
 
 .card .copy, .cards .copy {
-	padding: 20px;
+	padding: 20px 20px 0 20px;
 }
 
 .bordered {

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1573,16 +1573,9 @@ blockquote.pull-quote.quote p.attrib {
 
 
 .card, .cards > * {					/* use .card for single element; use .cards to style all children */
-    padding: 20px;
     background: var(--lightest-gray);
  /* box-shadow: 5px 5px 7px var(--light-gray); */
     border: 1px solid #ccc;	
-}
-
-.cards .news.item figure {				/* neccessary to make the image extend to the borders of the card and allow text padding to remain unchanged */
-    width: calc(100% + 40px);
-    margin-top: -20px;
-    margin-left: -20px;
 }
 
 .cards.grid > * {					 /* kills additional padding for grid layout */


### PR DESCRIPTION
Various changes to news objects when formatted as cards, including making the entire container clickable on hover.

Removes hacks that are no longer required due to recent markup changes.

