### PR TITLE
Full-bleed container margin change

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1893,6 +1893,11 @@ a.content-button.secondary:hover {
     .body-container.two-col {
      grid-template-columns: 1fr;
     }
+
+.body-container.two-col .full-bleed-section {
+    width: calc(100% + 30px);
+    margin: 0 0 0 -15px;
+    }	
 }  
 
 /* In-content Image */

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1891,12 +1891,12 @@ a.content-button.secondary:hover {
 
 @media only screen and (max-width: 720px) {
     .body-container.two-col {
-     grid-template-columns: 1fr;
+       grid-template-columns: 1fr;
     }
 
-.body-container.two-col .full-bleed-section {
-    width: calc(100% + 30px);
-    margin: 0 0 0 -15px;
+    .body-container.two-col .full-bleed-section {
+       width: calc(100% + 30px);
+       margin: 0 0 0 -15px;
     }	
 }  
 


### PR DESCRIPTION
Allows the full-bleed container to extend to the edge of the viewport in a 2-column layout, emulating the behavior in a one-column layout