### PR TITLE
Text-only heading width/margin fix

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -2240,11 +2240,11 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
 }
 
 .hero.simple .hero-content {
-    max-width: 1230px;
+    max-width: 900px;
     width: 100%;
     padding-left: 15px;	
     padding-right: 15px;
-    margin: auto;
+    margin: calc(50% - 610px);
 }
 
 .hero.simple .hero-content h1 {
@@ -2333,6 +2333,12 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
 }
 
 /* ===== MEDIA QUERIES  =================================== */
+
+@media screen and (max-width:1220px){
+    .hero.simple .hero-content {
+	margin:0;
+     }
+}
 
 @media only screen and (max-width: 960px) {
     .hero-content {


### PR DESCRIPTION
Prevents the text-only hero from spanning the entire width of the page container on desktop (1230px). Sets a max width of 900px and uses margin calc to align to the left edge. (Not sure if this solution is hacky or creative, lol)