### PR TITLE
Remove grid-col-list styles

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -2781,11 +2781,13 @@ UPDATE THIS CLASS FOR THE PAGE
     grid-row-gap: 20px;
 }
 
+/* these rules can be deleted if this class is removed from the component */
+/* 
 .grid-col-list {
     display: flex;
     flex-direction: column;
-    grid-row-gap: 0;
-}
+    grid-row-gap: 0;  
+} */
 
 .item.grid-col {
     background-color: #fff;


### PR DESCRIPTION
These are from an older prototype of the list layout and they're interfering the news item display in some cases. Commenting out the rules for now -- we will need to revisit how this class is called into the CMS component post-launch