### PR TITLE
Add hover animation to buttons

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -294,21 +294,6 @@ blockquote.pull-quote.quote-marks p:not(.attrib):after {
   z-index: -10;
 }
 
-.callout a.content-button {
-  border: 2px solid var(--dark-gray);
-  padding: 15px;
-  display: inline-block;
-  text-decoration: none;
-  font-weight: 500;
-  margin-top: 20px;
-  margin-bottom: 0;
-  color: var(--dark-gray);
-  background: none;
-  text-transform: uppercase;
-  font-size: 1rem;
-  letter-spacing: .025rem;
-}
-
 .callout p.callout-content-label {
   font-size: 1.0625rem;
   font-weight: 700;

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1665,30 +1665,95 @@ svg {
 
 /* === INPUTS ================================= */
 
-a.content-button {
-    border: 1px solid;
-    background-color: var(--lightest-gray);
-    padding: 10px;
-    margin: 0 10px 20px 0;
-    display: inline-block;
-    text-decoration: none;
+.body-container a.content-button {
+  padding: 12px;
+  margin: 0 10px 20px 0;
+  display: inline-block;
+  text-decoration: none;
+  cursor: pointer;
+  text-transform: uppercase;
+  color: var(--graphite);
+  font-weight: 400;
+  box-shadow: inset 0 0 0 2px var(--gold-solid);
+  transition: color 0.25s 0.25s;
+  position: relative;
+  background: #FB0
 }
 
 a.content-button:not(:last-of-type) {
     margin-right: 10px;
   }
 
-a.content-button.secondary {
+.body-container a.content-button.secondary {
     background: none;
+    box-shadow: inset 0 0 0 2px var(--graphite);
 }
 
 a.content-button:hover {
-    background-color: var(--light-gray-80);
+    background-color: unset;
 }
 
 a.content-button.secondary:hover {
     background-color: var(--lightest-gray);
 }
+
+.content-button::before, .content-button::after {
+  border: 0 solid transparent;
+  box-sizing: border-box;
+  content: "";
+  pointer-events: none;
+  position: absolute;
+  width: 0;
+  height: 0;
+  top: 0;
+  left: 0;
+}
+.content-button::before {
+  border-bottom-width: 2px;
+  border-left-width: 2px;
+}
+.content-button::after {
+  border-top-width: 2px;
+  border-right-width: 2px;
+}
+
+.content-button:hover::before, .content-button:hover::after {
+  border-color: var(--graphite);
+  transition: border-color 0s, width 0.25s, height 0.25s;
+  width: 100%;
+  height: 100%;
+}
+
+.content-button.secondary:hover::before, .content-button.secondary:hover::after {
+  border-color: var(--gold-solid);
+}
+
+.content-button:hover::before {
+  transition-delay: 0s, 0.25s, 0s;
+}
+.content-button:hover::after {
+  transition-delay: 0s, 0s, 0.25s;
+}
+
+.content-button {
+  cursor: pointer;
+  padding: 10px;
+  text-transform: uppercase;
+  color: var(--graphite);
+  font-weight: 400;
+}
+
+.content-button i {
+  padding: 0 4px 0 3px;
+  transition: padding .25s 0s ease-in-out;	
+} 
+
+.content-button:hover i {
+  color: var(--gold-solid);
+  transition: color .25s .25s;
+  padding: 0 2px 0 5px;
+  transition: padding .25s .25s
+} 
 
 /* === BODY CONTENT CONTAINERS ======== */
 


### PR DESCRIPTION
- Adds hover animation to primary and secondary button types.
- Removes callout-specific button styles from design-layer.css and moves all button hover styling to newsroom.css

We will likely need to refactor this a bit and add additional scope for inverse and ghost buttons for use on dark backgrounds.