### PR TITLE
Update Q and A selector logic

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -826,7 +826,7 @@ p.pub-flag.tu-magazine img {
     top: -3px;
 }
 
-.q-and-a p:before {
+.q-and-a h3 + p:before {
     content: 'A:';
     top: -1px;
 }


### PR DESCRIPTION
Refined Q and A selector to target only the first p after the h3. This prevents answers with multiple paragraphs and other elements (like captions) from getting an "A" character