### PR TITLE
Prelaunch fixes

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -43,7 +43,7 @@
     text-decoration: none;
 }
 
-.news.item h3, .cards .news.item h3 {
+.news.item h3, .item.text-block p a, .cards .news.item h3 {
     background: linear-gradient(#fb0, #fb0);
     background-size: 0 3px;
     background-repeat: no-repeat;
@@ -53,7 +53,7 @@
     display: inline;
 }
 
-.news.item:hover h3 {
+.news.item:hover h3, .item.text-block p a:hover {
     background-size: 100% 3px;
     background-position-x: 0;
     text-decoration: none;

--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -8,8 +8,6 @@
 
 /* ===== INTERACTION ===== */
 
-/* These changes will not work until the XSL changes are in place to wrap all media objects in an <a> element */
-
 /* Full Hover State for News Items */
 
 .news.item a {

--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -97,7 +97,7 @@
 
 /* Background Deco Pattern - Left */
 
-.tigertooth-enabled.background-left .grid-snippet:first-of-type:before {
+.tigertooth-enabled.background-left-v1 .grid-snippet:first-of-type:before {
     content: url(https://www.towson.edu/_resources/images/newsroom-deco/tt-pattern-1.svg);
     position: absolute;
     top: -100px;
@@ -106,14 +106,32 @@
     z-index: -1000;    
 }
 
+.tigertooth-enabled.background-left-v2 .grid-snippet:first-of-type:before {
+    content: url(https://www.towson.edu/_resources/images/newsroom-deco/tt-pattern-3.svg);
+    position: absolute;
+    top: -100px;
+    left: -350px;
+    width: 300px;
+    z-index: -1000;    
+}
+
 /* Background Deco Pattern - Right */
 
-.tigertooth-enabled.background-right .grid-snippet:first-of-type:after {
+.tigertooth-enabled.background-right-v1 .grid-snippet:first-of-type:after {
     content: url(https://www.towson.edu/_resources/images/newsroom-deco/tt-pattern-2.svg);
     position: absolute;
     top: 100px;
     right: -600px;
     width: 500px;
+    z-index: -1000;
+}
+
+.tigertooth-enabled.background-right-v2 .grid-snippet:first-of-type:after {
+    content: url(https://www.towson.edu/_resources/images/newsroom-deco/tt-pattern-3.svg);
+    position: absolute;
+    top: 100px;
+    right: -350px;
+    width: 300px;
     z-index: -1000;
 }
 

--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -82,7 +82,7 @@
 /* Lead Article Deco Wrapper */
 
 .tigertooth-enabled .lead .item.news .copy:before {
-    content: url(https://www.towson.edu/_dev/_news-mag-redesign/_images/_deco/tt-1.svg);
+    content: url(https://www.towson.edu/_resources/images/newsroom-deco/tt-accent-1.svg);
     width: 100px;
     position: absolute;
     top: -33px;
@@ -90,7 +90,7 @@
 }
 
 .tigertooth-enabled .lead .item.news .copy:after {
-    content: url(https://www.towson.edu/_dev/_news-mag-redesign/_images/_deco/tt-2.svg);
+    content: url(https://www.towson.edu/_resources/images/newsroom-deco/tt-accent-2.svg);
     width: 80px;
     position: absolute;
     top: -24px;
@@ -100,7 +100,7 @@
 /* Background Deco Pattern - Left */
 
 .tigertooth-enabled.background-left .grid-snippet:first-of-type:before {
-    content: url(https://www.towson.edu/_dev/_news-mag-redesign/_images/_deco/tt-pattern-1.svg);
+    content: url(https://www.towson.edu/_resources/images/newsroom-deco/tt-pattern-1.svg);
     position: absolute;
     top: -100px;
     left: -450px;
@@ -111,7 +111,7 @@
 /* Background Deco Pattern - Right */
 
 .tigertooth-enabled.background-right .grid-snippet:first-of-type:after {
-    content: url(https://www.towson.edu/_dev/_news-mag-redesign/_images/_deco/tt-pattern-2.svg);
+    content: url(https://www.towson.edu/_resources/images/newsroom-deco/tt-pattern-2.svg);
     position: absolute;
     top: 100px;
     right: -600px;
@@ -283,7 +283,7 @@ blockquote.pull-quote.quote-marks p:not(.attrib):after {
   }
 
 .callout.left:before {
-  content: url(https://www.towson.edu/_dev/_news-mag-redesign/_images/_deco/tt-1.svg);
+  content: url(https:/www.towson.edu/_resources/images/newsroom-deco/tt-accent-1.svg);
   width: 130px;
   position: absolute;
   top: -37px;
@@ -291,7 +291,7 @@ blockquote.pull-quote.quote-marks p:not(.attrib):after {
 }
 
 .callout.left:after {
-  content: url(https://www.towson.edu/_dev/_news-mag-redesign/_images/_deco/tt-2.svg);
+  content: url(https://www.towson.edu/_resources/images/newsroom-deco/tt-accent-2.svg);
   width: 64px;
   position: absolute;
   bottom: -123px;

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1685,6 +1685,10 @@ svg {
   background: #FB0
 }
 
+.body-container p:has(a.content-button) {  /* kills double-margin when a button is accidentally wrapped in a p */
+    margin: 0;
+}
+
 a.content-button:not(:last-of-type) {
     margin-right: 10px;
   }
@@ -2604,7 +2608,7 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
    }
    
    .profiles.repeating-list.grid .list-item:hover img {
-	   filter: brightness(40%) grayscale(1);
+	   filter: brightness(25%) grayscale(1);
    }
    
    .profiles.repeating-list.grid .list-item .repeating-list-image {
@@ -2615,7 +2619,7 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
 	   position: absolute;
 	   bottom: 0;
 	   opacity: 0;
-	   padding: 10px 20px;
+	   padding: 10px 30px;
 	   line-height: 1.375rem;
    }
    


### PR DESCRIPTION
Includes the following updates:

- Changes directory paths for tigertooth
- Changes tigertooth naming conventions for better extensibility
- Adds support for alternative tigertooth background pattern
- Makes text-only link hover styles consistent with other versions
- Prevents CTA buttons from having double margins when accidentally places in a p tag
- Darkens "profile" image hover state to avoid text contrast issues
