### PR TITLE
Fix link hover state

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -458,6 +458,7 @@ ul.links-list {
 
 ul.links-list li a {
     text-decoration: none;
+    border-bottom: 0;	
 }
 
 .links-list li a:after {

--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -3,7 +3,8 @@
 /* Kills underlined links in nav and news objects */
 
 .header-container a, .grid-snippet a {
-  text-decoration: none;
+    text-decoration: none;
+    border-bottom: 0;
 }
 
 /* ===== INTERACTION ===== */

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -3671,15 +3671,17 @@ form.search_form_mobile {
 }
 
 .footer-link {
-    color: #ffbb00; 
+    color: #fb0; 
     text-decoration: none;
     margin-right: 20px;
+    border-bottom: none;	
 }
 
 .footer-copy .footer-link {
     color: var(--white);
     text-decoration: none;
     margin-right: 5px;
+    border-bottom: none;	
 }
 
 .footer-copy .footer-link:hover {

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -2111,7 +2111,7 @@ UPDATE THIS CLASS FOR THE PAGE
     font-weight: 500;
     text-transform: uppercase;
     letter-spacing: .15rem;
-    color: var(-dark-gray);
+    color: var(--dark-gray);
 }
 
 p.tag-primary + h3 {

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -655,6 +655,10 @@ blockquote.pull-quote.quote p.attrib {
     background-color: var(--graphite);
     color: var(--lighter-gray);
 }
+
+.color-block.dark a:hover {
+    color: var(--graphite);
+}
 	
 .color-block.dark .intro-text, .color-block.dark blockquote.pull-quote p {
     color: inherit;

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -438,8 +438,7 @@ img {
 /* Base Typography */
 
 a {
-    text-decoration: underline 2px var(--gold-solid);
-    text-underline-position: under;    
+    border-bottom: 2px solid var(--gold-solid); 
 }
 
 h1 {
@@ -512,7 +511,7 @@ strong {
     background-size: 200% 0px;
     background-position: 200% 100%;
     background-repeat: no-repeat;
-    padding: 3px;
+    padding: 3px 3px 0 3px;
     margin: -3px;
     transition: background-size .3s, background-position .3s .3s;
 }


### PR DESCRIPTION
Discovered a late-game bug in which text-decoration declarations were not being shown in Safari, resulting in most links not having underlines. Couldn't quickly find the root cause, this changes text-decoration to margin-bottom which has the same visual effect but works in Safari too.

Also fixes a typo in one of the color variables.