### PR TITLE
Post implementation masthead fixes; hero label styling

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -255,17 +255,19 @@
 
    =========================================== */
    
-.accent{
+.accent {
    pointer-events: none;
 }
-.container-nav {
+
+/* .container-nav {
 	position: relative;
 	max-width: 1200px;
 	margin: 0 auto;
 	display: block;
 	padding: 0 10px;
 	box-sizing: border-box;
-}
+} */
+
 .container-nav.large {
 	max-width: 1363px;
 }
@@ -2469,6 +2471,7 @@ p.tag-primary + h3 {
 	position: relative;
 	width:550px;
 }
+
 .pub-list-slide {
     display: none;
     padding: 10px 0px;
@@ -2484,6 +2487,12 @@ p.tag-primary + h3 {
 }
 
 
+@media only screen and (max-width: 500px) {
+    .utility-nav .tu-home-link {
+        padding-right: 0;
+    }
+}
+
 /* ===== MASTHEAD ==================== */
 
 .heading-constrain {
@@ -2498,8 +2507,6 @@ p.tag-primary + h3 {
     max-width: 100%;
 }
 
-.masthead-container {
-}
 
 .masthead-logo-container {
     width: 160px;
@@ -2516,7 +2523,7 @@ p.tag-primary + h3 {
     display: flex;
 }
 
-.vertical-id p {
+p.vertical-name {
     font-weight: 700;
     font-size: 1.3rem;
     text-transform: uppercase;
@@ -2562,23 +2569,12 @@ p.tag-primary + h3 {
 .heading-constrain.nav-flex-wrap {
     display: flex;
     justify-content: space-between;
-    align-items: center;
+    align-items: start;
+    height: 80px;
 }
 
 .heading-constrain.nav-flex-wrap a {
-	display: contents;
-	z-index: 100001;
-}
-
-@media (max-width: 499px) {
-	.heading-constrain.nav-flex-wrap a {
-		display: contents;
-		z-index: 100001;
-	}
-}
-
-.mobile-nav {
-    display: block !important;
+    display: contents;
 }
 
 .nav-container {
@@ -2666,9 +2662,8 @@ button.search i {
     position: relative;
 }
 
-/*must define the original color */
 p.vertical-name {
-	color:#000000
+	color:#000000;
 }
 
 .alt p.vertical-name {
@@ -2724,36 +2719,39 @@ background-size: 8.94px 6.03px;
     color: var(--gold-solid);
 }
 
-
-/* MOCKUP PROPERTIES FOR SMALL SCREENS
-// These styles are a rough representation of how we want things to LOOK on mobile.
-// A lot this CSS is for demo only and will need to be redone to fit neatly into the codebase. */
-
 @media only screen and (max-width: 960px) {
     .nav-container, ul.publication-items {
         display: none;
     }
+
     .global-header {
         height: 80px;
     }
+
     .masthead-logo-container {
         width: 120px;
         height: 80px;
         background: linear-gradient(213.4deg,transparent 20px,#000 20px); 
     }
-    .vertical-id p {
+
+    p.vertical-name {
         width: 120px;
+        font-size: 1.125rem;
+        letter-spacing: .0625rem;
+        padding: 0 5px;    
     }
+
     .masthead-logo-container svg {
         padding: 16px 20px 20px 12px;
     }
-    .vertical-id p {
-        font-size: 1.125rem !important; /* only used here to override the inline CSS on this demo page. */
-        letter-spacing: .0625rem !important;/* only used here to override the inline CSS on this demo page. */
-        padding: 0 5px;
-    }
+
     .global-header:after {
-        right: -38px;;
+        right: -38px;
+    }
+
+    .alt p.vertical-name {
+        font-size: 2.125rem;
+        letter-spacing: .1875rem;
     }
 }
 
@@ -2764,7 +2762,7 @@ background-size: 8.94px 6.03px;
 }
 
 .mobile-menu-icon-container {
-        margin: -20px 10px 0 0;
+        margin-top: 30px;
 }
 
 .mobile-menu-icon-container .icon {
@@ -2777,25 +2775,52 @@ background-size: 8.94px 6.03px;
     .nav-container, ul.publication-items {
         display: none;
     }
+
     .global-header {
         height: 60px;
     }
+
+    .heading-constrain.nav-flex-wrap {
+	  height: 60px;
+    }
+	
     .masthead-logo-container {
         width: 90px;
         height: 60px;
-        background: linear-gradient(213.4deg,transparent 15px,#000 15px);    
+        background: linear-gradient(213.4deg,transparent 15px,#000 15px);      
     }
-    .vertical-id p {
+
+    .alt .masthead-logo-container {
+        width: 70px; 
+    }
+
+    p.vertical-name {
         width: 90px;
+        font-size: .85rem;
+        letter-spacing: .025rem;
+        padding: 0 5px;       
     }
+
+    .alt p.vertical-name {
+        font-size: 1.375rem;
+        letter-spacing: .125rem;
+        top: 5px;
+        padding-left: 15px;    
+    }    
+
     .masthead-logo-container svg {
         padding: 12px 15px 15px 8px;
     }
-    .vertical-id p {
-        font-size: .85rem !important; /* only used here to override the inline CSS on this demo page. */
-        letter-spacing: .025rem !important;/* only used here to override the inline CSS on this demo page. */
-        padding: 0 5px;
+
+    .alt .masthead-logo-container svg {
+        padding: 20px 15px 5px 5px;
     }
+
+    .mobile-menu-icon-container {
+        margin-top: 22px;
+	margin-right: 0;
+}
+	
     .global-header:after {
         display: none;
     }
@@ -2924,7 +2949,6 @@ background-size: 8.94px 6.03px;
 	font-style: normal;
 	background: black;
 	border: 2px solid white;
-	color: #000000;
 	height: 13px;
 	padding: 10px 16px;
 	width: 60px;
@@ -2967,12 +2991,10 @@ background-size: 8.94px 6.03px;
 
 .stripe.graphite .nav-container .search-section.active input {
     border: 1px solid var(--white);
-    color: #ffffff;
 }
 
 .stripe.graphite .nav-container .search-section button {
     color: var(--white);
-    border: var(--white) solid 1px;
 }
 
 .stripe.graphite .nav-container .search-section i {
@@ -3120,8 +3142,6 @@ form.search_form_mobile {
 } */
 
 
-
-
 .mobile-nav {
 	position: relative;
 	right: 0px;
@@ -3130,7 +3150,10 @@ form.search_form_mobile {
 	font-weight: 700;
 	font-size: 0.9375rem;
 	margin-right: 0;
+        z-index: 100001;
+	display: block !important;
 }
+
 .hamburger {
 	float: none;
 	right: auto;
@@ -3148,14 +3171,10 @@ form.search_form_mobile {
 	padding: 58px 0px;
 }
 
-
-
 .navigation-top.temphead-top .main-nav ul .btn {
 	margin: 0px;
 	font-weight: 700;
 }
-
-
 
 .mobile-links-nav {
 	opacity: 0;
@@ -3202,10 +3221,6 @@ form.search_form_mobile {
     transition: 0.3s ease all;
 }
 
-
-
-
-
 /* ====================================================
    ====================================================
 
@@ -3216,7 +3231,7 @@ form.search_form_mobile {
 
 
 .mobile-links-nav ul {
-	margin: 0 35px 0 10px;
+	margin: 0 25px 0 10px;
 	text-align: right;
 }
 .mobile-links-nav ul li {
@@ -3419,8 +3434,6 @@ form.search_form_mobile {
 	animation: slideInFromRight 500ms forwards;
 }
 
-
-
 .hamburger-nav {
 	cursor: pointer;
 	width: 20px;
@@ -3430,10 +3443,9 @@ form.search_form_mobile {
 	transition: 0.3s ease all;
 	position: relative;
 	right: 7px;
-	top: 10px;
 	display: inline-block;
-	float: left;
 }
+
 .hamburger-nav i {
 	border-radius: 2px;
 	content: '';
@@ -3754,10 +3766,6 @@ form.search_form_mobile {
       margin-bottom: 10px; /* Optional: Adds space between the links */
     }
   }
-
-  a#ou_directedit {
-    border-bottom: 0;
-}
 
 /* ====================================================
    ====================================================

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1347,6 +1347,20 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
     text-transform: uppercase;
 }
 
+.hero-content p.hero-label {
+    font-size: 1.125rem;
+    color: var(--gold-solid);
+    background: var(--graphite);
+    padding: 5px 8px;
+    text-transform: uppercase;
+    font-weight: 600;
+    letter-spacing: .15rem;
+    margin-bottom: 20px;
+    display: inline-block;
+    width: fit-content;    
+  }
+
+
 /* Variant - No Image */
 
 .hero.simple {
@@ -1400,11 +1414,23 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
 }
 
  .hero.primary .hero-content h1 {
-    border-left: 2px solid var(--gold-solid);
     padding-left: 20px;
     filter: var(--text-contrast);
     text-shadow: 1px 1px 1px #000;	 
 }
+
+.hero.primary .hero-content h1:before {
+    border-left: 2px solid #fb0;
+    content: '';
+    height: 100%;
+    left: 0px;
+    position: absolute;
+    bottom: 0;
+  }
+
+.hero.primary .hero-content:has(.hero-label) h1:before {
+    height: calc(100% + 50px);
+  }
 
  .hero.primary .hero-content p.subhead {
     filter: var(--text-contrast);
@@ -1420,6 +1446,12 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
  .hero.primary .hero-content p.byline-item, .hero.primary .hero-content p.pub-date {
   font-size: inherit;
   color: inherit;
+}
+
+.hero.primary p.hero-label {
+    text-shadow: none;
+    background-color: #1a1a1a;
+    margin-left: 20px;  
 }
 
 /* Variant - SQ Image */
@@ -1489,6 +1521,11 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
         font-size: 1.25rem;
         line-height: 1.75rem;
     }
+    .hero-content p.hero-label {
+     font-size: .9375rem;
+     font-weight: 500;
+     padding: 3px 5px;
+   }	
     .hero.primary .hero-image .gradient  {
         background-image: linear-gradient(180deg, rgba(0, 0, 0, 0) 75%, rgba(0, 0, 0, .85) 100%);
 	opacity: unset; /* can be removed if opacity is eliminated at a higher specificity later */
@@ -2763,6 +2800,7 @@ background-size: 8.94px 6.03px;
 
 .mobile-menu-icon-container {
         margin-top: 30px;
+	margin-right: 10px;
 }
 
 .mobile-menu-icon-container .icon {


### PR DESCRIPTION
- Adjusts specific masthead elements including logo, publication title, and the heading wrapper to make sizing more consistent across breakpoints, especially for the magazine (`.alt`) masthead
Reduces scoping conflicts by changing a number of selectors from `.vertical-id p` to `p.vertical-name`, which were previously used interchangeably to target the same element
Eliminates a combination of `padding`, `margin` and `top`/`bottom` attributes to position the hamburger menu in favor of `margin` wherever possible.
- Carries over z-index fixes to the hamburger from the last change
- Adds stying support for hero "visible label" field ahead of its introduction to the CMS.