### PR TITLE
Adjust byline container for square image hero

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -493,7 +493,7 @@ strong {
     font-weight: 700;
     float: left;
     margin-right: 5px;
-    top: 3px;
+    top: 1px;
     position: relative;
     color: var(--lighter-gray);
     -webkit-text-stroke: 1px black;
@@ -1146,6 +1146,9 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
         font-size: 1.125rem;
         line-height: 1.75rem;
     }
+    .drop-cap {
+        top: -1px;
+    }	
 }
 
 

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1501,11 +1501,15 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
     overflow: auto;
     }
 
-	/* AB change from -50 to -10 for Accessibility */
 .hero.alt .hero-content {
-    margin-left: -10px;
+    margin-left: 0;
     padding: 0;
     max-width: calc( 100% + 50px);    
+}
+
+.hero.alt .byline-container {
+    display: flex;	
+    justify-content: start;
 }
 
 /* ===== HERO MEDIA QUERIES  =================================== */


### PR DESCRIPTION
Addresses an issue that caused byline start to misalign when two bylines took up a different amount of space. Bylines now align to the top of the flex container in the .alt variant of the hero. Does not impact other variants.