### PR TITLE
Adjust timeline margins and grid

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -1017,7 +1017,6 @@ p.pub-flag.tu-magazine img {
     background: var(--gold-solid);
     display: inline-block;
     float: right;
-    margin-right: 0px;
    }
 
 /* Container query for containers smaller than 500px wide */

--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -994,6 +994,7 @@ p.pub-flag.tu-magazine img {
     display: grid;
     position: relative;
     grid-template-columns: 140px auto;
+    grid-column-gap: 40px;
    }
 
   .timeline:before {
@@ -1001,7 +1002,7 @@ p.pub-flag.tu-magazine img {
     border-left: 2px dotted var(--gold-solid);
     height: 100%;
     position: absolute;
-    left: 140px;
+    left: 160px;
     }
 
 .timeline-item {
@@ -1016,27 +1017,21 @@ p.pub-flag.tu-magazine img {
     background: var(--gold-solid);
     display: inline-block;
     float: right;
-    margin-right: 30px;
-   }
-
-  .entry {
-    padding-left: 30px;
+    margin-right: 0px;
    }
 
 /* Container query for containers smaller than 500px wide */
 @container (max-width: 500px) {
     .date p {
-        font-size: 1.75rem;
-        margin-right: 10px;
+        font-size: 1.8275rem;
     }
     .timeline {
         grid-template-columns: 80px auto;
+	grid-column-gap: 30px;
+	margin-left: 10px;
     }
     .timeline:before {
-        left: 85px;
-    }
-    .entry {
-        padding-left: 20px;
+        left: 95px;
     }
 }
 

--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -1023,7 +1023,7 @@ p.pub-flag.tu-magazine img {
 /* Container query for containers smaller than 500px wide */
 @container (max-width: 500px) {
     .date p {
-        font-size: 1.8275rem;
+        font-size: 1.8125rem;
     }
     .timeline {
         grid-template-columns: 80px auto;


### PR DESCRIPTION
- Makes timeline CSS slightly more efficient by removing static margins in favor of grid-gap value
- Gives left-rag breathing room in containers smaller than 500px, allowing for better text fit
