### PR TITLE
Visual design tweaks - repeating list images and Q&A bug

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -942,12 +942,12 @@ p.pub-flag.tu-magazine img {
     font-weight: 700;
 }
 
-.q-a-item .q-a-question h3:first-of-type:before{
+.q-a-item .q-a-question > h3:first-of-type:before{
     content: 'Q:';
     top: -3px;
 }
 
-.q-a-item .q-a-answer p:first-of-type:before {
+.q-a-item .q-a-answer > p:first-of-type:before {
     content: 'A:';
     top: -1px;
 }

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1671,12 +1671,16 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
             margin-top: 0;
    }
 
-.repeating-list.cards .repeating-list-body {
+   .repeating-list.cards .repeating-list-body {
 	   padding: 20px;
    }
 
-.repeating-list.cards .list-item {
+   .repeating-list.cards .list-item {
 	   grid-gap: 0;
+   }
+
+   .repeating-list.list.rounds .list-item {    /* reduces image size when round images are used */
+           grid-template-columns: 1.5fr 3fr;
    }
    
    /* ------ Grid Variant ------ */


### PR DESCRIPTION
- Reduces size of repeating list images when .list and .rounds variants are applied concurrently.
- Fixes bug in the Q and A snippet in which an “A” label can erroneously be applied to a nested pull quote or other descendent p element.