### PR TITLE
Byline wrap bugfix

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1375,7 +1375,7 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
     margin-right: 30px;
     font-weight: 500;
     text-transform: uppercase;
-    max-width: 350px;
+    text-wrap: pretty;
     color: var(--dark-gray);
     display: inline-block;
     margin-left: 26px;

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1375,11 +1375,17 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
     margin-right: 30px;
     font-weight: 500;
     text-transform: uppercase;
-    text-wrap: pretty;
+    text-wrap: balance;
     color: var(--dark-gray);
     display: inline-block;
     margin-left: 26px;
     position: relative;	
+}
+/* Override text-wrap: balance with text-wrap: pretty if supported */
+@supports (text-wrap: pretty) {
+.hero-content p.byline-item {
+    text-wrap: pretty;
+  }
 }
 
 .hero-content p.byline-item .icon {

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -1377,7 +1377,7 @@ img.round, figure.round, .round img, .rounds img {        /* use .round for a si
     text-transform: uppercase;
     text-wrap: balance;
     color: var(--dark-gray);
-    display: inline-block;
+    display: inline-flex;
     margin-left: 26px;
     position: relative;	
 }


### PR DESCRIPTION
Addresses situations where long bylines wrap awkwardly by:
 - introducing `text-wrap: pretty` with a `text-wrap: balance` fallback
 - changing `inline-block` to `inline-flex`
 - killing the element max-width