### PR TITLE
Add class to add text labels

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -530,6 +530,13 @@ strong {
     border-bottom-width: 1px;
 }
 
+span.highlight {
+    background: var(--graphite);
+    color: var(--gold-solid);
+    padding-left: .5ch;
+    padding-right: .5ch;
+}
+
 /* Decorative Section Breaks */
 
 hr {


### PR DESCRIPTION
Adds the .highlight class to turn text into a label-style element. Uses ch width units to allow consistent styling when used within p tags or heading elements.