### PR TITLE
Fix tigertooth on full 1-col articles

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -152,6 +152,10 @@
   --margin-offset: -100px;  
 }
 
+.body-container:not(.two-col) .body-section .tigertooth-bg {  /* allows tigertooth to work on 1-col article pages with minimal style overrides */
+	width: 700px;
+}
+
 .tigertooth-bg.pattern-1.left:before {
     content: url(https://www.towson.edu/_resources/images/newsroom-deco/tt-pattern-1.svg);
     position: absolute;

--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -315,6 +315,10 @@ blockquote.pull-quote.quote-marks p:not(.attrib):after {
     height: unset
 }
 
+.full-bleed-section .content-constrain .content-grid figure {
+    height: 100%;
+}
+
 /* Normalizes the top alignment of main body and sidebar when one or both sections lead with an element with a margin-top value other than 0 */
 
 .body-container.two-col .main-content .body-section > *:first-of-type,

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -890,8 +890,15 @@ a.content-button:hover {
 
 .full-bleed-section > .content-constrain {  /* Allows margin-contrained content in the full-bleed region. This allows a margin-constrained sub-container within full bleed. The primary use case is to set off margin-constrained content in a full-bleed color block. */
     width: calc(100% - 40px);
-    margin: 30px auto;
+    margin: 30px 0;
     max-width: 700px;
+	padding: 10px 0 20px 0;
+}
+
+@media only screen and (max-width: 720px) {
+	.full-bleed-section > .content-constrain {
+	    margin: 30px auto;
+	}
 }
 
 .body-container p.caption, .body-container figcaption.caption {


### PR DESCRIPTION
Adjusts width constraints to allow tigertooth to be placed on article pages (specifically one-col articles).

Also adjusts spacing when a full-bleed region is used in a two-column layout to allow more space above and below content.