### PR TITLE
HF - Full width color block content alignment

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -890,9 +890,9 @@ a.content-button:hover {
 
 .full-bleed-section > .content-constrain {  /* Allows margin-contrained content in the full-bleed region. This allows a margin-constrained sub-container within full bleed. The primary use case is to set off margin-constrained content in a full-bleed color block. */
     width: calc(100% - 40px);
-    margin: 30px 0;
+    margin: 30px auto;
     max-width: 700px;
-	padding: 10px 0 20px 0;
+    padding: 10px 0 20px 0;
 }
 
 @media only screen and (max-width: 720px) {


### PR DESCRIPTION
Hotfix -- rolls back margin change in full-width color blocks from 0 back to "auto" to address broken alignment on production pages