### PR TITLE
Minor style tweaks for magazine

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -721,7 +721,7 @@ p.pub-flag.tu-magazine img {
 
 .icon i {
   color: var(--gold-solid);
-  margin-top: 20px;
+  margin-top: 23px;
 }
 
 .color-block.gold .icon i {

--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -721,7 +721,7 @@ p.pub-flag.tu-magazine img {
 
 .icon i {
   color: var(--gold-solid);
-  margin-top: 23px;
+  margin-top: 24px;
 }
 
 .color-block.gold .icon i {

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -537,6 +537,11 @@ span.highlight {
     padding-right: .5ch;
 }
 
+.color-block.dark span.highlight {
+    background: var(--gold-solid);
+    color: var(--graphite);
+}
+
 /* Decorative Section Breaks */
 
 hr {
@@ -1034,6 +1039,20 @@ a.content-button:hover {
 
 .body-container.two-col .sidebar {
     display: block;
+}
+
+/* the following rules change spacing between sidebar elements when multiple instances are used consecutively */
+
+.secondary-content:has(.sidebar + .sidebar) .sidebar {
+	margin: 0;
+}
+
+.secondary-content:has(.sidebar + .sidebar) .sidebar.shim-padding-40 {
+	padding: 20px 40px;
+}
+
+.secondary-content:has(.sidebar + .sidebar) .sidebar:last-of-type {
+	margin-bottom: 20px;
 }
 
 @media only screen and (max-width: 1200px) {

--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -900,6 +900,10 @@ a.content-button:hover {
     padding: 10px 0 20px 0;
 }
 
+.secondary-content .full-bleed-section > .content-constrain {
+    margin: 0 20px;
+}
+
 @media only screen and (max-width: 720px) {
 	.full-bleed-section > .content-constrain {
 	    margin: 30px auto;


### PR DESCRIPTION
1. Adjusts height of icon in icon lists
2. Adds secondary style for`.highlight` text treatment when the element is used in `.color-block.dark`
3. Reduces top and bottom margin of the `.full-bleed-section` when used as a color block in the sidebar
4. Eliminates soacebetween sidebar elements when multiple instances are used consecutively
5. 