### PR TITLE
Add styles for image callout link hover effects

### DIFF
--- a/css/design-layer.css
+++ b/css/design-layer.css
@@ -642,6 +642,14 @@ ul.links-list li a {
     position: relative;
 }
 
+.image-callout .text-block p a {
+    border-bottom: 1px dashed;
+}
+
+.image-callout .text-block p a:hover {
+    background: none;
+}
+
 .image-callout .item.text-block .tag-primary, .image-callout .item.text-block h2 {
     grid-column-start: 1;
 }


### PR DESCRIPTION
Changes the link behavior from an animation to a simple dotted underline. While this style doesn't match any existing patterns, it's better than the alternative of no underline in the default state. May rethink this later.