### PR TITLE
Fix margin specificity issue in heading-with-label

### DIFF
--- a/css/newsroom.css
+++ b/css/newsroom.css
@@ -451,7 +451,7 @@ span.highlight.tag {
 }
 	
 .heading-with-label h2 {
-	margin: 30px 10px 0 0;
+	margin: 30px 10px 0 0 !important; /* quick fix to overcome specificity issues -- needs to be refactored */
 	flex-shrink: 0;
 }
 


### PR DESCRIPTION
Added !important to margin for specificity fix.